### PR TITLE
Correct the distance displayed in the viewer

### DIFF
--- a/object detection/birds eye viewer/python/cv_viewer/tracking_viewer.py
+++ b/object detection/birds eye viewer/python/cv_viewer/tracking_viewer.py
@@ -124,7 +124,7 @@ class TrackingViewer:
                 cv2.putText(left_display, "ID " + str(obj.id), (int(position_image[0]) - 20, int(position_image[1]) - 30),
                             cv2.FONT_HERSHEY_COMPLEX_SMALL, 0.5, (255, 255, 255, 255), 1)
                 if math.isfinite(obj.position[2]):
-                    text = "{:.1f}M".format(abs(obj.position[2] / 1000.0))
+                    text = "{:.1f}M".format(abs(obj.position[2]))
                     cv2.putText(left_display, text, (int(position_image[0]) - 20, int(position_image[1])),
                                 cv2.FONT_HERSHEY_COMPLEX_SMALL, 0.5, (255, 255, 255, 255), 1)
         cv2.addWeighted(left_display, 0.7, overlay, 0.3, 0.0, left_display)


### PR DESCRIPTION
The tracking viewer shows all detected objects at 0.0M. This is because the distance is already in meters, so it is not necessary to divide the value by 1000 before diplaying it.