### PR TITLE
BugFix for GPSReader Initialization

### DIFF
--- a/global localization/live/python/gnss_reader/gpsd_reader.py
+++ b/global localization/live/python/gnss_reader/gpsd_reader.py
@@ -25,8 +25,8 @@ class GPSDReader:
         print("Successfully connected to GPSD")
         print("Waiting for GNSS fix")
         received_fix = False
+        self.gnss_getter = self.client.dict_stream(convert_datetime=True, filter=["TPV", "SKY"])
         while not received_fix:
-            self.gnss_getter = self.client.dict_stream(convert_datetime=True, filter=["TPV", "SKY"])
             gpsd_data = next(self.gnss_getter)
             if "class" in gpsd_data and gpsd_data["class"] == "TPV" and "mode" in gpsd_data and gpsd_data["mode"] >=2:
                 received_fix = True


### PR DESCRIPTION
This PR fixes a bug where the generator `self.gnss_getter` was being recreated on each iteration of the while loop. As a result, `gpsd_data = next(self.gnss_getter)` was called only once per loop iteration, leading to unnecessary computational overhead. Additionally, after testing locally, on every new generator creation inside the `while` loop, the first message received was consistently a `SKY` message, causing the initialization step to fail. (I am not pretty sure why it was always be `SKY` messages). After debugging and testing, moving the generator creation outside the `while` loop resolved these issues. Please let me know if there are any questions or further improvements needed.